### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
           --crate cobalt \
           --force \
           --target x86_64-unknown-linux-gnu \
-          --tag v0.17.4
+          --tag v0.16.5
         echo COBALT_BIN=~/.cargo/bin/cobalt >> $GITHUB_ENV
     - name: Build
       run: ${{ env.COBALT_BIN }} build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,5 @@
 name: Publish
-on:
-  push:
-    branches: main
+on: push
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -20,6 +18,7 @@ jobs:
     - name: Build
       run: ${{ env.COBALT_BIN }} build
     - name: Deploy
+      if: steps.extract_branch.outputs.branch == 'main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Note: this required downgrading cobalt to 0.16.5. 0.17.4 is packaged differently which means the script to download a release binary doesn't work.